### PR TITLE
.editorconfig: Enforce tabs across repository

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+indent_style=tab


### PR DESCRIPTION
Rust files were already using tabs for indentation. Adding an explicit
.editorconfig file helps editors auto indent.