### PR TITLE
src/lib: Make raise_fd_limit return new limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdlimit"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Parity Technologies<admin@parity.io>"]
 license = "Apache-2.0"
 description = "Utility crate for raising file descriptors limit for OSX and Linux"

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ on Windows does nothing
 add in Cargo.toml: 
 ```
 [dependencies]
-fdlimit = "0.1.1"
+fdlimit = "0.2.0"
 ```


### PR DESCRIPTION
Add return value `Option<u64>` to `raise_fd_limit` returning the new file descriptor limit to the caller.

I am not able to test this on a MacOS or iOS machine. `cargo build --target x86_64-apple-darwin` compiles. Could someone with a Mac test this?

As far as I can tell [`rlimit::rlim_cur` is a `u64` on both 64 bit OS and 32 bit OS](https://docs.rs/libc/0.2.76/libc/struct.rlimit.html). Please correct me if I am wrong. `cargo build --target i686-unknown-linux-musl` succeeds. 

Patch bumps the crate's version to `v0.2.0` for a new release.