### PR TITLE
src/lib: Convert libc::rlim_t to u64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub fn raise_fd_limit() -> Option<u64> {
 			panic!("raise_fd_limit: error calling setrlimit: {}", err);
 		}
 
-		Some(rlim.rlim_cur)
+		Some(rlim.rlim_cur.into())
 	}
 }
 


### PR DESCRIPTION
Previously a27a68d wrongly assumed `libc::rlim_t` to be a `u64` on all
platforms. Instead the following is the case:

- x86_64-unknown-linux-gnu: u64
- x86_64-apple-darwin: u64
- i686-unknown-linux-musl: u64
- i686-unknown-linux-gnu: u32
- ...

There are different options in order to compile on all platforms:

- Return `usize`. While `usize` would work for most platforms,
`i686-unknown-linux-musl` is an exception. Thus casting would be needed
which introduces yet another way to panic. In addition `usize` should be
used to index into collections, not so much to represent actual data.

- Return `libc::rlim_t`. This type is not present on all platforms. In
addition exposing a `libc` type in the public interface unnecessarily
ties us to `libc`.

- Return `u32`. Would require a fallible cast on all `u64` platforms.

- Return `u64`. Supported on all platforms. It is not the most space
efficient option.

Given that memory efficiency (`u32` vs `u64`) is irrelevant in this
context, compared to the involved system calls, this commit converts the
limit to `u64` before returning for all platforms.

Fixes https://github.com/paritytech/fdlimit/issues/5.