### PR TITLE
Bumped version to 0.2.1 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ on Windows does nothing
 add in Cargo.toml: 
 ```
 [dependencies]
-fdlimit = "0.2.0"
+fdlimit = "0.2.1"
 ```
 
 # License


### PR DESCRIPTION
Problem: The readme file still suggests using the outdated version 0.2.0, which is incompatible with 32 bit architectures.
Solution: Suggest to use version 0.2.1,  which is compatible with 32 bit architectures, in the readme file.