### PR TITLE
Return an error instead of panicking, and add a test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,13 @@ name = "fdlimit"
 version = "0.2.1"
 authors = ["Parity Technologies<admin@parity.io>"]
 license = "Apache-2.0"
+edition = "2018"
 description = "Utility crate for raising file descriptors limit for OSX and Linux"
 repository = "https://github.com/paritytech/fdlimit"
 
 [dependencies]
 libc = "0.2"
+thiserror = "1.0.24"
+
+[dev-dependencies]
+matches = "0.1.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate libc;
+use std::io;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("Error calling {method}: {source}")]
+pub struct RaiseLimitError {
+    method: &'static str,
+    source: io::Error,
+}
 
 /// Raise the soft open file descriptor resource limit to the smaller of the
 /// kernel limit and the hard resource limit.
 ///
-/// Returns [`Some`] with the new limit.
+/// Returns [`Ok(Some(u64))`] with the new limit.
 ///
-/// # Panics
-///
-/// Panics if [`libc::sysctl`], [`libc::getrlimit`] or [`libc::setrlimit`]
-/// fail.
 ///
 /// darwin_fd_limit exists to work around an issue where launchctl on Mac OS X
 /// defaults the rlimit maxfiles to 256/unlimited. The default soft limit of 256
@@ -30,87 +34,119 @@ extern crate libc;
 /// on the number of cores available.
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[allow(non_camel_case_types)]
-pub fn raise_fd_limit() -> Option<u64> {
-	use std::cmp;
-	use std::io;
-	use std::mem::size_of_val;
-	use std::ptr::null_mut;
+pub fn raise_fd_limit() -> Result<Option<u64>, RaiseLimitError> {
+    use std::cmp;
+    use std::mem::size_of_val;
+    use std::ptr::null_mut;
 
-	unsafe {
-		static CTL_KERN: libc::c_int = 1;
-		static KERN_MAXFILESPERPROC: libc::c_int = 29;
+    unsafe {
+        static CTL_KERN: libc::c_int = 1;
+        static KERN_MAXFILESPERPROC: libc::c_int = 29;
 
-		// The strategy here is to fetch the current resource limits, read the
-		// kern.maxfilesperproc sysctl value, and bump the soft resource limit for
-		// maxfiles up to the sysctl value.
+        // The strategy here is to fetch the current resource limits, read the
+        // kern.maxfilesperproc sysctl value, and bump the soft resource limit for
+        // maxfiles up to the sysctl value.
 
-		// Fetch the kern.maxfilesperproc value
-		let mut mib: [libc::c_int; 2] = [CTL_KERN, KERN_MAXFILESPERPROC];
-		let mut maxfiles: libc::c_int = 0;
-		let mut size: libc::size_t = size_of_val(&maxfiles) as libc::size_t;
-		if libc::sysctl(&mut mib[0], 2, &mut maxfiles as *mut _ as *mut _, &mut size,
-				  null_mut(), 0) != 0 {
-			let err = io::Error::last_os_error();
-			panic!("raise_fd_limit: error calling sysctl: {}", err);
-		}
+        // Fetch the kern.maxfilesperproc value
+        let mut mib: [libc::c_int; 2] = [CTL_KERN, KERN_MAXFILESPERPROC];
+        let mut maxfiles: libc::c_int = 0;
+        let mut size: libc::size_t = size_of_val(&maxfiles) as libc::size_t;
+        if libc::sysctl(
+            &mut mib[0],
+            2,
+            &mut maxfiles as *mut _ as *mut _,
+            &mut size,
+            null_mut(),
+            0,
+        ) != 0
+        {
+            let err = io::Error::last_os_error();
+            return Err(RaiseLimitError {
+                method: "libc",
+                source: err,
+            });
+        }
 
-		// Fetch the current resource limits
-		let mut rlim = libc::rlimit{rlim_cur: 0, rlim_max: 0};
-		if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
-			let err = io::Error::last_os_error();
-			panic!("raise_fd_limit: error calling getrlimit: {}", err);
-		}
+        // Fetch the current resource limits
+        let mut rlim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
+            let err = io::Error::last_os_error();
+            return Err(RaiseLimitError {
+                method: "getrlimit",
+                source: err,
+            });
+        }
 
-		// Bump the soft limit to the smaller of kern.maxfilesperproc and the hard
-		// limit
-		rlim.rlim_cur = cmp::min(maxfiles as libc::rlim_t, rlim.rlim_max);
+        // Bump the soft limit to the smaller of kern.maxfilesperproc and the hard
+        // limit
+        rlim.rlim_cur = cmp::min(maxfiles as libc::rlim_t, rlim.rlim_max);
 
-		// Set our newly-increased resource limit
-		if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) != 0 {
-			let err = io::Error::last_os_error();
-			panic!("raise_fd_limit: error calling setrlimit: {}", err);
-		}
+        // Set our newly-increased resource limit
+        if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) != 0 {
+            let err = io::Error::last_os_error();
+            return Err(RaiseLimitError {
+                method: "setrlimit",
+                source: err,
+            });
+        }
 
-		Some(rlim.rlim_cur)
-	}
+        Ok(Some(rlim.rlim_cur))
+    }
 }
 
 /// Raise the soft open file descriptor resource limit to the hard resource
 /// limit.
 ///
-/// Returns [`Some`] with the new limit.
+/// Returns [`Ok(Some(u64))`] with the new limit.
 ///
-/// # Panics
-///
-/// Panics if [`libc::getrlimit`] or [`libc::setrlimit`] fail.
 #[cfg(any(target_os = "linux"))]
 #[allow(non_camel_case_types)]
-pub fn raise_fd_limit() -> Option<u64> {
-	use std::io;
+pub fn raise_fd_limit() -> Result<Option<u64>, RaiseLimitError> {
+    unsafe {
+        // Fetch the current resource limits
+        let mut rlim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
+            let err = io::Error::last_os_error();
+            return Err(RaiseLimitError {
+                method: "getrlimit",
+                source: err,
+            });
+        }
 
-	unsafe {
-		// Fetch the current resource limits
-		let mut rlim = libc::rlimit{rlim_cur: 0, rlim_max: 0};
-		if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
-			let err = io::Error::last_os_error();
-			panic!("raise_fd_limit: error calling getrlimit: {}", err);
-		}
+        // Set soft limit to hard imit
+        rlim.rlim_cur = rlim.rlim_max;
 
-		// Set soft limit to hard imit
-		rlim.rlim_cur = rlim.rlim_max;
+        // Set our newly-increased resource limit
+        if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) != 0 {
+            let err = io::Error::last_os_error();
+            return Err(RaiseLimitError {
+                method: "setrlimit",
+                source: err,
+            });
+        }
 
-		// Set our newly-increased resource limit
-		if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) != 0 {
-			let err = io::Error::last_os_error();
-			panic!("raise_fd_limit: error calling setrlimit: {}", err);
-		}
-
-		Some(rlim.rlim_cur.into())
-	}
+        Ok(Some(rlim.rlim_cur.into()))
+    }
 }
 
-/// Returns [`None`].
+/// Returns [`Ok(None)`].
 #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "linux")))]
-pub fn raise_fd_limit() -> Option<u64> {
-	None
+pub fn raise_fd_limit() -> Result<u64, RaiseLimitError> {
+    Ok(None)
+}
+
+#[cfg(test)]
+pub mod test {
+    use crate::raise_fd_limit;
+
+    #[test]
+    fn test_raise_limit() {
+        matches::assert_matches!(raise_fd_limit(), Ok(Some(_)))
+    }
 }


### PR DESCRIPTION
Panicking in a library like this seems like bad form. This PR makes the `raise_fd_limit` return an error instead, so the caller can appropriately handle it.

I also added a single test and ran `cargo fmt` on the code.