### PR TITLE
Relax `thiserror` requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ repository = "https://github.com/paritytech/fdlimit"
 
 [dependencies]
 libc = "0.2"
-thiserror = "1.0.50"
+thiserror = "1.0"


### PR DESCRIPTION
The `thiserror = "1.0.50"` requirement conflicts with any other crate that tries to pin this dependency to an older version, as seen in https://github.com/watchexec/watchexec/issues/703.